### PR TITLE
86 navigate to review page

### DIFF
--- a/components/ArticleActions.vue
+++ b/components/ArticleActions.vue
@@ -122,7 +122,7 @@
           <Icon class="align-middle" name="heroicons:link-16-solid" />View
         </NuxtLink>
       </span>
-      <span v-if="toggle === true">
+      <span v-if="toggle === true && article.status !== 'ready'">
         <NuxtLink
           v-if="article.userId === user.id"
           :to="`/articles/edit/${route.params.id}`"

--- a/components/ArticleActions.vue
+++ b/components/ArticleActions.vue
@@ -124,10 +124,18 @@
       </span>
       <span v-if="toggle === true">
         <NuxtLink
+          v-if="article.userId === user.id"
           :to="`/articles/edit/${route.params.id}`"
           class="du-btn text-md"
         >
           <Icon class="align-middle" name="heroicons:link-16-solid" />Edit
+        </NuxtLink>
+        <NuxtLink
+          v-if="article.userId !== user.id"
+          :to="`/articles/review/${route.params.id}`"
+          class="du-btn text-md"
+        >
+          <Icon class="align-middle" name="heroicons:link-16-solid" />Review
         </NuxtLink>
       </span>
       <details :ref="refs.dropdown" class="du-dropdown du-dropdown-end">
@@ -141,7 +149,7 @@
           <li v-if="article.status === 'review'" @click="modals.confirmSendToDraft">
             <button>Send to Draft</button>
           </li>
-          <li v-if="article.status === 'draft' || article.status === 'ready'" @click="modals.confirmSendToReview">
+          <li v-if="article.status === 'draft'" @click="modals.confirmSendToReview">
             <button>Send to Review</button>
           </li>
           <li

--- a/components/Dashboard/ArticleRows.vue
+++ b/components/Dashboard/ArticleRows.vue
@@ -20,11 +20,18 @@
 
     <td class="w-40 min-w-20 text-right text-sm font-medium whitespace-nowrap">
       <NuxtLink
-        v-if="article.status === 'review' || article.status === 'draft'"
+        v-if="userStore.user && (article.status === 'review' || article.status === 'draft') && userStore.user.id === article.userId"
         class="text-indigo-600 hover:text-indigo-900"
         :to="`/articles/edit/${article._id}`"
       >
         Edit
+      </NuxtLink>
+      <NuxtLink
+        v-if="userStore.user && article.status === 'review' && userStore.user.id !== article.userId"
+        class="text-indigo-600 hover:text-indigo-900"
+        :to="`/articles/review/${article._id}`"
+      >
+        Review
       </NuxtLink>
       <NuxtLink
         v-if="article.status === 'ready'"
@@ -39,6 +46,8 @@
 
 <script setup lang="ts">
 const props = defineProps<{ article: Article }>()
+
+const userStore = useUserStore()
 
 const formatDate = computed(() => {
   const date = new Date(props.article.updatedAt)

--- a/pages/articles/[id].vue
+++ b/pages/articles/[id].vue
@@ -3,7 +3,7 @@
     <main v-if="article && user">
       <div class="mx-auto flex max-w-3xl justify-between pt-8 md:max-w-7xl">
         <h1 class="text-3xl font-bold text-gray-900">Article Preview</h1>
-        <ArticleActions :article="article" :user="user" :toggle="toggle" />
+        <ArticleActions :article="article" :user="user" :toggle="true" />
       </div>
 
       <ArticleComponent :article="article" />
@@ -20,7 +20,6 @@ const article = ref<Article>()
 const userStore = useUserStore()
 const { user } = storeToRefs(userStore)
 const route = useRoute()
-const toggle = true
 
 onBeforeMount(async () => {
   article.value = await requestEndpoint<Article>(

--- a/pages/articles/edit/[id].vue
+++ b/pages/articles/edit/[id].vue
@@ -2,7 +2,7 @@
   <div v-if="article && user" class="mx-auto max-w-3xl py-8 md:max-w-7xl">
     <div class="flex justify-between">
       <h1 class="text-3xl font-bold text-gray-900">Edit Article</h1>
-      <ArticleActions :article="article" :user="user" :toggle="toggle" />
+      <ArticleActions :article="article" :user="user" :toggle="false" />
     </div>
     <div v-if="article.editorResponses.length != 0 && article.status === 'review'" class="max-w-7xl py-4">
       <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
@@ -102,7 +102,6 @@ const article = ref<Article>()
 const userStore = useUserStore()
 const modals = useModalStore()
 const { user } = storeToRefs(userStore)
-const toggle = false
 
 onBeforeMount(async () => {
   article.value = await requestEndpoint<Article>(

--- a/pages/articles/edit/[id].vue
+++ b/pages/articles/edit/[id].vue
@@ -4,6 +4,19 @@
       <h1 class="text-3xl font-bold text-gray-900">Edit Article</h1>
       <ArticleActions :article="article" :user="user" :toggle="toggle" />
     </div>
+    <div v-if="article.editorResponses.length != 0 && article.status === 'review'" class="max-w-7xl py-4">
+      <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
+      <div class="mt-1 flex flex-col w-140 rounded-md shadow-md md:w-160 lg:w-180 flex-wrap">
+          <h3 class="flex justify-between items-start gap-2 px-3 py-3 whitespace-normal break-all"
+              v-for="response in article.editorResponses" 
+              :key="response.name"
+              >
+              <span class="flex-1 break-all">
+                  {{ response.name }}: {{ response.text }}
+              </span>
+          </h3>
+      </div>
+    </div>
     <div class="max-w-7xl py-4">
       <label class="text-md block font-medium text-gray-700"> Title </label>
       <div class="mt-1 flex w-80 rounded-md shadow-sm md:w-100 lg:w-120">

--- a/pages/articles/review/[id].vue
+++ b/pages/articles/review/[id].vue
@@ -56,11 +56,14 @@ const modals = useModalStore()
 const newNote = ref<string>('')
 
 const { user } = storeToRefs(userStore)
-const toggle = true
+const toggle = false
 
 function deleteNotes(response: { name: string; text: string }) {
+    if (response.name !== userStore.user?.name) return
+
     const index = article.value?.editorResponses.findIndex((note) => note === response)
     if (index === undefined || index === -1) return
+
     article.value?.editorResponses.splice(index, 1)
     requestEndpoint(`/cms/${route.params.id}`, 'PUT', article.value)
 }
@@ -73,7 +76,7 @@ async function saveNewNote() {
         })
         newNote.value = ''
     }
-
+    console.log(article.value)
     modals.saveArticle()
 }
 

--- a/pages/articles/review/[id].vue
+++ b/pages/articles/review/[id].vue
@@ -17,8 +17,15 @@
                         </span>
 
                         <button 
+                            v-if="response.name === user.name"
                             class="shrink-0 pl-2 text-gray-500 hover:text-red-500 font-bold text-2xl leading-none"
                             @click="deleteNotes(response)"
+                        >
+                            <Icon name="heroicons:x-mark-16-solid" />                            
+                        </button>
+                        <button 
+                            v-if="response.name !== user.name"
+                            class="shrink-0 pl-2 text-gray-300 font-bold text-2xl leading-none"
                         >
                             <Icon name="heroicons:x-mark-16-solid" />                            
                         </button>
@@ -32,6 +39,7 @@
                     v-model="newNote"
                     type="text"
                     class="du-input text-md block flex-1 shadow-sm rounded border border-gray-300 pl-3 py-3"
+                    @keydown="handleKeydown"
                     />
                     <button @click="saveNewNote" class="ml-2 du-btn du-btn-success shadow-sm"> Send </button>
                 </div>
@@ -69,15 +77,21 @@ function deleteNotes(response: { name: string; text: string }) {
 }
 
 async function saveNewNote() {
-    if (newNote.value.trim() !== '') {
-        article.value?.editorResponses.push({
-        name: userStore.user?.name || 'Anonymous',
-        text: newNote.value.trim(),
-        })
-        newNote.value = ''
-    }
-    console.log(article.value)
+    if (newNote.value.trim() === '') return
+
+    article.value?.editorResponses.push({
+    name: userStore.user?.name || 'Anonymous',
+    text: newNote.value.trim(),
+    })
+    newNote.value = ''   
+
     modals.saveArticle()
+}
+
+function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+        saveNewNote()
+    }
 }
 
 onBeforeMount(async () => {

--- a/pages/articles/review/[id].vue
+++ b/pages/articles/review/[id].vue
@@ -3,7 +3,7 @@
         <main v-if="article && user" class="mx-auto max-w-3xl py-8 md:max-w-7xl">
             <div class="flex justify-between">
                 <h1 class="text-3xl font-bold text-gray-900">Review Article</h1>
-                <ArticleActions :article="article" :user="user" :toggle="toggle" />
+                <ArticleActions :article="article" :user="user" :toggle="false" />
             </div>
             <div v-if="article.editorResponses.length != 0" class="max-w-7xl py-4">
                 <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
@@ -64,7 +64,7 @@ const modals = useModalStore()
 const newNote = ref<string>('')
 
 const { user } = storeToRefs(userStore)
-const toggle = false
+
 
 function deleteNotes(response: { name: string; text: string }) {
     if (response.name !== userStore.user?.name) return


### PR DESCRIPTION
Added a NuxtLink in the ArticleRows to allow travel to the review page of articles.
Made it so that the option is either edit or review depending on the ownership of the article.
Changed the editorNotes delete function to only allow editors to delete their own notes.
Added visible editorNotes on the Edit article page if the article.status = ‘review’.
Added link Review to replace the Edit link when you are on the View page of an article you don’t own and is in review.
Added the ability to press Enter as well as the Send button when adding editorNotes
Added a visual indicator (lighter x) to illustrate the inability to delete editorNotes not owned by you.
Edit link in articles with status ‘ready’ has been removed.
