### PR TITLE
95 editor notes not breaking the words good

### DIFF
--- a/pages/articles/edit/[id].vue
+++ b/pages/articles/edit/[id].vue
@@ -7,11 +7,11 @@
     <div v-if="article.editorResponses.length != 0 && article.status === 'review'" class="max-w-7xl py-4">
       <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
       <div class="mt-1 flex flex-col w-140 rounded-md shadow-md md:w-160 lg:w-180 flex-wrap">
-          <h3 class="flex justify-between items-start gap-2 px-3 py-3 whitespace-normal break-all"
+          <h3 class="flex justify-between items-start gap-2 px-3 py-3 whitespace-normal break-words"
               v-for="response in article.editorResponses" 
               :key="response.name"
               >
-              <span class="flex-1 break-all">
+              <span class="flex-1 break-words">
                   {{ response.name }}: {{ response.text }}
               </span>
           </h3>

--- a/pages/articles/edit/[id].vue
+++ b/pages/articles/edit/[id].vue
@@ -7,11 +7,11 @@
     <div v-if="article.editorResponses.length != 0 && article.status === 'review'" class="max-w-7xl py-4">
       <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
       <div class="mt-1 flex flex-col w-140 rounded-md shadow-md md:w-160 lg:w-180 flex-wrap">
-          <h3 class="flex justify-between items-start gap-2 px-3 py-3 whitespace-normal break-words"
+          <h3 class="flex min-w-0 max-w-full justify-between items-start gap-2 px-3 py-3"
               v-for="response in article.editorResponses" 
               :key="response.name"
               >
-              <span class="flex-1 break-words">
+              <span class="flex-1 break-words overflow-hidden">
                   {{ response.name }}: {{ response.text }}
               </span>
           </h3>

--- a/pages/articles/review/[id].vue
+++ b/pages/articles/review/[id].vue
@@ -8,11 +8,11 @@
             <div v-if="article.editorResponses.length !== 0" class="max-w-7xl py-4">
                 <label class="text-md block font-medium text-gray-700"> Editor Notes </label>
                 <div class="mt-1 flex flex-col w-140 rounded-md shadow-md md:w-160 lg:w-180 flex-wrap">
-                    <h3 class="flex justify-between items-start gap-2 px-3 py-3 whitespace-normal break-all"
+                    <h3 class="flex min-w-0 max-w-full justify-between items-start gap-2 px-3 py-3"
                         v-for="response in article.editorResponses" 
                         :key="response.name"
                         >
-                        <span class="flex-1 break-all">
+                        <span class="flex-1 break-words overflow-hidden">
                             {{ response.name }}: {{ response.text }}
                         </span>
 


### PR DESCRIPTION
Made it so that editor notes wouldn't fly off the screen into the never-ending, deep, whitespace to the right of the screen.